### PR TITLE
Fix the name parameter for secretsStorage for AWS secrets manager 

### DIFF
--- a/modules/cluster/irsa.tf
+++ b/modules/cluster/irsa.tf
@@ -397,9 +397,9 @@ data "aws_iam_policy_document" "secrets-manager-policy" {
       "secretsmanager:UpdateSecret",
     ]
     resources = [
-
-      "*",
-
+      "arn:${data.aws_partition.current.partition}:secretsmanager:${var.region}:${local.project}:secret:secret/data/lighthouse/*",
+      "arn:${data.aws_partition.current.partition}:secretsmanager:${var.region}:${local.project}:secret:secret/data/jx/*",
+      "arn:${data.aws_partition.current.partition}:secretsmanager:${var.region}:${local.project}:secret:secret/data/nexus/*"
     ]
   }
 }

--- a/templates/jx-requirements.yml.tpl
+++ b/templates/jx-requirements.yml.tpl
@@ -37,7 +37,7 @@ vault:
 %{ endif }
 %{ endif }
 %{ if use_asm }
-secretStorage: asm
+secretStorage: secretsManager
 %{ endif }
 %{ if enable_backup }
 velero:


### PR DESCRIPTION
The value given for AWS secrets manager should be secretsManager, to comply with the naming used elsewhere in Jenkins X 3